### PR TITLE
Fix info-card button

### DIFF
--- a/153699.user.js
+++ b/153699.user.js
@@ -281,6 +281,7 @@
         removeClass(moviePlayerElement, 'autohide-controlbar autominimize-controls-aspect autohide-controls-fullscreenonly autohide-controls hide-controls-when-cued autominimize-progress-bar autominimize-progress-bar-fullscreenonly autohide-controlbar-fullscreenonly autohide-controls-aspect autohide-controls-fullscreen autominimize-progress-bar-non-aspect');
         addClass(moviePlayerElement, 'autominimize-progress-bar autohide-controls hide-controls-when-cued');
         // ytwp.log(moviePlayerElement.classList);
+        moviePlayerElement.insertBefore(moviePlayerElement.querySelector('button[aria-owns="iv-drawer"]'), moviePlayerElement.firstChild);
     };
     ytwp.html5.update = function() {
         if (!ytwp.html5.playerInstances)


### PR DESCRIPTION
The info-card button is inaccessible when using this script, moving it above the video feed in the DOM fixes it in both the old and the new UI.