### PR TITLE
Fix false positives in YouTube watch URL matching

### DIFF
--- a/153699.user.js
+++ b/153699.user.js
@@ -267,14 +267,14 @@
     ytwp.isWatchUrl = function (url) {
         if (!url)
             url = uw.location.href;
-        if (url.match(/https?:\/\/(www\.)?youtube.com\/(c|channel|user)\/[^\/]+\/live/)) {
+        if (url.match(/^https?:\/\/(www\.)?youtube.com\/(c|channel|user)\/[^\/]+\/live/)) {
             if (document.querySelector('ytd-browse')) {
                 return false
             } else {
                 return true
             }
         }
-        return url.match(/https?:\/\/(www\.)?youtube.com\/watch\?/);
+        return url.match(/^https?:\/\/(www\.)?youtube.com\/watch\?/);
     };
 
     ytwp.setTheaterMode = function(enable) {


### PR DESCRIPTION
We don't want to match [https://example.com/?url=https://www.youtube.com/watch?](https://example.com/?url=https://www.youtube.com/watch?)

Fixes #92.