### PR TITLE
Update CSS selector for Enhancer for YouTube mini-player

### DIFF
--- a/153699.user.js
+++ b/153699.user.js
@@ -6,7 +6,7 @@
 // @icon            https://s.ytimg.com/yts/img/favicon_32-vflOogEID.png
 // @homepageURL     https://github.com/Zren/ResizeYoutubePlayerToWindowSize/
 // @namespace       http://xshade.ca
-// @version         139
+// @version         140
 // @include         http*://*.youtube.com/*
 // @include         http*://youtube.com/*
 // @include         http*://*.youtu.be/*

--- a/153699.user.js
+++ b/153699.user.js
@@ -6,7 +6,7 @@
 // @icon            https://s.ytimg.com/yts/img/favicon_32-vflOogEID.png
 // @homepageURL     https://github.com/Zren/ResizeYoutubePlayerToWindowSize/
 // @namespace       http://xshade.ca
-// @version         140
+// @version         139
 // @include         http*://*.youtube.com/*
 // @include         http*://youtube.com/*
 // @include         http*://*.youtu.be/*

--- a/153699.user.js
+++ b/153699.user.js
@@ -177,7 +177,7 @@
 
     var scriptHtmlSelector = 'html:not([fullscreen="true"])';
     var scriptBodySelector = 'body.' + scriptBodyClassId; // body.ytwp-window-player
-    scriptBodySelector += ':not(.enhancer-for-youtube-pinned-player)'; // Support "Enhancer for Youtube" (Pull Request #51)
+    scriptBodySelector += ':not(.efyt-mini-player)'; // Support "Enhancer for Youtube" (Pull Request #51)
     var scriptSelector = scriptHtmlSelector + ' ' + scriptBodySelector;
 
     var videoContainerId = 'player';

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 <h3>Changelog</h3>
 
+## v140 - March 21, 2026
+
+* Update CSS selector for Enhancer for YouTube mini-player
+
 ## v139 - April 10, 2024
 
 * Fix page top margin as certain elements seem to ignore the CSS properties completely (Issue #88)

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,5 @@
 <h3>Changelog</h3>
 
-## v140 - March 21, 2026
-
-* Update CSS selector for Enhancer for YouTube mini-player
-
 ## v139 - April 10, 2024
 
 * Fix page top margin as certain elements seem to ignore the CSS properties completely (Issue #88)


### PR DESCRIPTION
Enhancer for YouTube changed the class name it applies to the `<body>` tag when its mini-player is active.

Old targeted class: `.enhancer-for-youtube-pinned-player`

Current active class: `.efyt-mini-player`

This PR updates the `scriptBodySelector` exclusion on line 180. This resolves the conflict where the resize script overrode the mini-player's dimensions, allowing the video to shrink correctly when the mini-player is toggled.